### PR TITLE
Fix cross-validation order bug

### DIFF
--- a/pancancer_evaluation/utilities/data_utilities.py
+++ b/pancancer_evaluation/utilities/data_utilities.py
@@ -209,7 +209,7 @@ def split_stratified(rnaseq_df, sample_info_df, num_folds=4, fold_no=1,
     ] = 'other'
 
     # now do stratified CV splitting and return the desired fold
-    kf = StratifiedKFold(n_splits=num_folds, random_state=seed)
+    kf = StratifiedKFold(n_splits=num_folds, shuffle=True, random_state=seed)
     for fold, (train_ixs, test_ixs) in enumerate(
             kf.split(rnaseq_df, sample_info_df.id_for_stratification)):
         if fold == fold_no:
@@ -266,7 +266,7 @@ def split_by_cancer_type(rnaseq_df, sample_info_df, holdout_cancer_type,
 
 def split_single_cancer_type(cancer_type_df, num_folds, fold_no, seed):
     """Split data for a single cancer type into train and test sets."""
-    kf = KFold(n_splits=num_folds, random_state=seed)
+    kf = KFold(n_splits=num_folds, shuffle=True, random_state=seed)
     for fold, (train_ixs, test_ixs) in enumerate(kf.split(cancer_type_df)):
         if fold == fold_no:
             train_df = cancer_type_df.iloc[train_ixs]

--- a/pancancer_evaluation/utilities/tcga_utilities.py
+++ b/pancancer_evaluation/utilities/tcga_utilities.py
@@ -148,7 +148,7 @@ def align_matrices(x_file_or_df, y, add_cancertype_covariate=True,
         x_df = x_file_or_df
 
     # select samples to use, assuming y has already been filtered by cancer type
-    use_samples = set(y.index).intersection(set(x_df.index))
+    use_samples = y.index.intersection(x_df.index)
     x_df = x_df.reindex(use_samples)
     y = y.reindex(use_samples)
 


### PR DESCRIPTION
Recently I noticed that running cross-validation multiple times using the same seed gives different results. This fixes that by switching from set intersections to Pandas built-in index intersections (the latter guarantees the same order every time). I've checked that this now leads to repeatable cross-validation results.

I'm also planning to add some regression tests to make sure this isn't happening in the future, but those will be part of my next (larger) PR.